### PR TITLE
Fix TextLoop effect bug

### DIFF
--- a/components/text-effect.tsx
+++ b/components/text-effect.tsx
@@ -73,14 +73,16 @@ export function TextLoop({ texts }: { texts: string[] }) {
   const [index, setIndex] = useState(0)
 
   useEffect(() => {
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       let next = index + 1
       if (next === texts.length) {
         next = 0
       }
       setIndex(next)
     }, 3 * 1000)
-  })
+
+    return () => clearTimeout(timeout)
+  }, [index, texts.length])
 
   return (
     <AnimatePresence mode="wait" initial={false}>


### PR DESCRIPTION
## Summary
- prevent repeated timeouts in `TextLoop`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68446f1d882483249f7d7377b1a1cf28