### PR TITLE
Fix company name capitalization on main page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,7 +134,7 @@ export default function Home() {
           </BioSection>
           <BioSection>
             <BioYear>Now</BioYear>
-            System Administrator at Mobifone Corporation
+            System Administrator at MobiFone Corporation
           </BioSection>
         </Section>
 


### PR DESCRIPTION
## Summary
- update company name to **MobiFone** on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68447200d1ac8324b1ef7c4fccd06de5