### PR TITLE
optimize: performance improvements and multi-domain support

### DIFF
--- a/components/chakra.tsx
+++ b/components/chakra.tsx
@@ -25,9 +25,16 @@ export default function Chakra({
 }
 
 export function getServerSideProps({ req }: { req: any }) {
+  const host =
+    (req.headers['x-forwarded-host'] as string) ||
+    (req.headers.host as string) ||
+    'dangdd.tech'
+  const protocol =
+    (req.headers['x-forwarded-proto'] as string) || 'https'
   return {
     props: {
-      cookies: req.headers.cookie ?? ''
+      cookies: req.headers.cookie ?? '',
+      baseUrl: `${protocol}://${host}`
     }
   }
 }

--- a/components/chakra.tsx
+++ b/components/chakra.tsx
@@ -24,17 +24,22 @@ export default function Chakra({
   )
 }
 
+const ALLOWED_HOSTS = ['dangdd.tech', 'dangdd.dev', 'ddangw.me']
+
 export function getServerSideProps({ req }: { req: any }) {
-  const host =
+  const rawHost =
     (req.headers['x-forwarded-host'] as string) ||
     (req.headers.host as string) ||
-    'dangdd.tech'
-  const protocol =
-    (req.headers['x-forwarded-proto'] as string) || 'https'
+    'dangdd.dev'
+  const rawProtocol = (req.headers['x-forwarded-proto'] as string) || 'https'
+  const host = rawHost.split(',')[0].trim()
+  const protocol = rawProtocol.split(',')[0].trim()
+  const bareHost = host.replace(/^www\./, '').split(':')[0]
+  const validatedHost = ALLOWED_HOSTS.find(h => bareHost === h) ?? 'dangdd.dev'
   return {
     props: {
       cookies: req.headers.cookie ?? '',
-      baseUrl: `${protocol}://${host}`
+      baseUrl: `${protocol}://www.${validatedHost}`
     }
   }
 }

--- a/components/earth.tsx
+++ b/components/earth.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import * as THREE from 'three'
+import {
+  WebGLRenderer,
+  PerspectiveCamera,
+  Vector3,
+  Scene,
+  SRGBColorSpace
+} from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 import { EarthSpinner, EarthContainer } from '@/components/earth-loader'
 import createEarth from '@/lib/model'
@@ -11,7 +17,7 @@ function easeOutCirc(x: number) {
 export default function Earth() {
   const refContainer = useRef<HTMLDivElement>(null)
   const [loading, setLoading] = useState(true)
-  const refRenderer = useRef<THREE.WebGLRenderer>()
+  const refRenderer = useRef<WebGLRenderer>()
 
   const handleWindowResize = useCallback(() => {
     const { current: renderer } = refRenderer
@@ -29,18 +35,18 @@ export default function Earth() {
       const scW = container.clientWidth
       const scH = container.clientHeight
 
-      const renderer = new THREE.WebGLRenderer({
+      const renderer = new WebGLRenderer({
         antialias: true,
         alpha: true
       })
       renderer.setPixelRatio(window.devicePixelRatio)
       renderer.setSize(scW, scH)
-      renderer.outputColorSpace = THREE.SRGBColorSpace
+      renderer.outputColorSpace = SRGBColorSpace
 
-      const target = new THREE.Vector3(0, 0, 0)
-      const initialCameraPosition = new THREE.Vector3(10, 0, 0)
+      const target = new Vector3(0, 0, 0)
+      const initialCameraPosition = new Vector3(10, 0, 0)
 
-      const camera = new THREE.PerspectiveCamera(20, scW / scH, 0.1, 1000)
+      const camera = new PerspectiveCamera(20, scW / scH, 0.1, 1000)
       camera.position.z = 5
       camera.position.copy(initialCameraPosition)
       camera.lookAt(target)
@@ -53,7 +59,7 @@ export default function Earth() {
       // controls.autoRotate = true
       controls.target = target
 
-      const scene = new THREE.Scene()
+      const scene = new Scene()
 
       // finish creating the Earth before animation
       let req: number = 0

--- a/components/layouts/main.tsx
+++ b/components/layouts/main.tsx
@@ -13,11 +13,17 @@ const Earth = dynamic(() => import('@/components/earth'), {
 
 export default function Main({
   children,
-  router
+  router,
+  baseUrl = 'https://dangdd.tech'
 }: {
   children?: React.ReactNode
   router: NextRouter
+  baseUrl?: string
 }) {
+  const pageUrl = `${baseUrl}${router.asPath}`
+  const imageUrl = `${baseUrl}/homepage.png`
+  const twitterDomain = baseUrl.replace(/^https?:\/\//, '').split(':')[0]
+
   return (
     <Box as="main" pb={8}>
       <Head>
@@ -27,25 +33,19 @@ export default function Main({
         <meta name="author" content="Đoàn Đình Đăng" />
         <meta name="author" content="d-dev" />
 
-        <meta property="og:url" content="https://www.dangdd.me" />
+        <meta property="og:url" content={pageUrl} />
         <meta property="og:type" content="website" />
         <meta property="og:title" content="Doan Dinh Dang | Homepage" />
         <meta property="og:description" content="Dang's Homepage" />
-        <meta
-          property="og:image"
-          content="https://www.dangdd.me/homepage.png"
-        />
+        <meta property="og:image" content={imageUrl} />
         <meta property="og:site_name" content="Doan Dinh Dang" />
 
         <meta name="twitter:card" content="summary_large_image" />
-        <meta property="twitter:domain" content="dangdd.me" />
-        <meta property="twitter:url" content="https://www.dangdd.me" />
+        <meta property="twitter:domain" content={twitterDomain} />
+        <meta property="twitter:url" content={pageUrl} />
         <meta name="twitter:title" content="Doan Dinh Dang | Homepage" />
         <meta name="twitter:description" content="Dang's Homepage" />
-        <meta
-          name="twitter:image"
-          content="https://www.dangdd.me/homepage.png"
-        />
+        <meta name="twitter:image" content={imageUrl} />
         <link
           rel="apple-touch-icon"
           sizes="180x180"

--- a/components/layouts/main.tsx
+++ b/components/layouts/main.tsx
@@ -14,7 +14,7 @@ const Earth = dynamic(() => import('@/components/earth'), {
 export default function Main({
   children,
   router,
-  baseUrl = 'https://dangdd.tech'
+  baseUrl = 'https://www.dangdd.dev'
 }: {
   children?: React.ReactNode
   router: NextRouter

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -97,12 +97,6 @@ export default function Navbar(props: NavbarProps) {
           flexGrow={1}
           mt={{ base: 4, md: 0 }}
         >
-          {/* <LinkItem href="/works" path={path}> */}
-          {/*   Works */}
-          {/* </LinkItem> */}
-          {/* <LinkItem href="/articles" path={path}> */}
-          {/*   Articles */}
-          {/* </LinkItem> */}
           <LinkItem href="/connect" path={path}>
             Connect
           </LinkItem>
@@ -135,12 +129,6 @@ export default function Navbar(props: NavbarProps) {
                 <MenuItem as={MenuLink} href="/">
                   About
                 </MenuItem>
-                {/* <MenuItem as={MenuLink} href="/works"> */}
-                {/*   Works */}
-                {/* </MenuItem> */}
-                {/* <MenuItem as={MenuLink} href="/articles"> */}
-                {/*   Articles */}
-                {/* </MenuItem> */}
                 <MenuItem as={MenuLink} href="/connect">
                   Connect
                 </MenuItem>

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -18,15 +18,20 @@ import getStarfield from '@/lib/starfield'
 const textureCache: Record<string, Texture> = {}
 const loader = new TextureLoader()
 
-function loadTexture(path: string) {
+function loadTexture(path: string, promises: Promise<Texture>[]) {
   if (!textureCache[path]) {
-    textureCache[path] = loader.load(path)
+    const promise = new Promise<Texture>((resolve, reject) => {
+      textureCache[path] = loader.load(path, resolve as any, undefined, reject)
+    })
+    promises.push(promise)
   }
   return textureCache[path]
 }
 
 export default async function createEarth(scene: Scene) {
   try {
+    const loadPromises: Promise<Texture>[] = []
+
     const earthGroup = new Group()
     earthGroup.rotation.z = (-23.4 * Math.PI) / 180
     scene.add(earthGroup)
@@ -34,29 +39,41 @@ export default async function createEarth(scene: Scene) {
     const geometry = new IcosahedronGeometry(1, details)
 
     const material = new MeshPhongMaterial({
-      map: loadTexture('/earth_texture/8081_earthmap4k.jpg'),
-      normalMap: loadTexture('/earth_texture/earthnormalmap.jpg'),
-      specularMap: loadTexture('/earth_texture/8081_earthspec4k.jpg'),
-      bumpMap: loadTexture('/earth_texture/8081_earthbump4k.jpg'),
-      lightMap: loadTexture('/earth_texture/8081_earthlights4k.jpg'),
+      map: loadTexture('/earth_texture/8081_earthmap4k.jpg', loadPromises),
+      normalMap: loadTexture('/earth_texture/earthnormalmap.jpg', loadPromises),
+      specularMap: loadTexture(
+        '/earth_texture/8081_earthspec4k.jpg',
+        loadPromises
+      ),
+      bumpMap: loadTexture('/earth_texture/8081_earthbump4k.jpg', loadPromises),
+      lightMap: loadTexture(
+        '/earth_texture/8081_earthlights4k.jpg',
+        loadPromises
+      ),
       bumpScale: 0.04
     })
     const earthMesh = new Mesh(geometry, material)
     earthGroup.add(earthMesh)
 
     const lightsMat = new MeshBasicMaterial({
-      lightMap: loadTexture('/earth_texture/8081_earthlights4k.jpg'),
+      lightMap: loadTexture(
+        '/earth_texture/8081_earthlights4k.jpg',
+        loadPromises
+      ),
       blending: AdditiveBlending
     })
     const lightsMesh = new Mesh(geometry, lightsMat)
     // earthGroup.add(lightsMesh)
 
     const cloudsMat = new MeshStandardMaterial({
-      map: loadTexture('/earth_texture/earthcloudmap.jpg'),
+      map: loadTexture('/earth_texture/earthcloudmap.jpg', loadPromises),
       transparent: true,
       opacity: 0.5,
       blending: AdditiveBlending,
-      alphaMap: loadTexture('/earth_texture/earthcloudmaptrans.jpg')
+      alphaMap: loadTexture(
+        '/earth_texture/earthcloudmaptrans.jpg',
+        loadPromises
+      )
     })
     const cloudsMesh = new Mesh(geometry, cloudsMat)
     cloudsMesh.scale.setScalar(1.003)
@@ -74,9 +91,10 @@ export default async function createEarth(scene: Scene) {
     sunLight.position.set(1, 0.5, 1.5)
     scene.add(sunLight)
 
+    await Promise.all(loadPromises)
     return { earthMesh, lightsMesh, cloudsMesh, glowMesh, stars }
   } catch (error) {
-    console.log('Error in creating The Earth: ', error)
+    console.error('Error in creating The Earth: ', error)
     throw new Error('Failed to create The Earth!')
   }
 }

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -1,53 +1,76 @@
-import * as THREE from 'three'
+import {
+  Group,
+  TextureLoader,
+  type Texture,
+  IcosahedronGeometry,
+  MeshPhongMaterial,
+  Mesh,
+  MeshBasicMaterial,
+  AdditiveBlending,
+  MeshStandardMaterial,
+  DirectionalLight,
+  type Scene
+} from 'three'
 import getFresnelMat from '@/lib/fresnel'
 import getStarfield from '@/lib/starfield'
 
-export default async function createEarth(scene: THREE.Scene) {
+// Cache textures to avoid reloading
+const textureCache: Record<string, Texture> = {}
+const loader = new TextureLoader()
+
+function loadTexture(path: string) {
+  if (!textureCache[path]) {
+    textureCache[path] = loader.load(path)
+  }
+  return textureCache[path]
+}
+
+export default async function createEarth(scene: Scene) {
   try {
-    const earthGroup = new THREE.Group()
+    const earthGroup = new Group()
     earthGroup.rotation.z = (-23.4 * Math.PI) / 180
     scene.add(earthGroup)
     const details = 12
-    const loader = new THREE.TextureLoader()
-    const geometry = new THREE.IcosahedronGeometry(1, details)
-    const material = new THREE.MeshPhongMaterial({
-      map: loader.load('/earth_texture/8081_earthmap4k.jpg'),
-      normalMap: loader.load('/earth_texture/earthnormalmap.jpg'),
-      specularMap: loader.load('/earth_texture/8081_earthspec4k.jpg'),
-      bumpMap: loader.load('/earth_texture/8081_earthbump4k.jpg'),
-      lightMap: loader.load('/earth_texture/8081_earthlights4k.jpg'),
+    const geometry = new IcosahedronGeometry(1, details)
+
+    const material = new MeshPhongMaterial({
+      map: loadTexture('/earth_texture/8081_earthmap4k.jpg'),
+      normalMap: loadTexture('/earth_texture/earthnormalmap.jpg'),
+      specularMap: loadTexture('/earth_texture/8081_earthspec4k.jpg'),
+      bumpMap: loadTexture('/earth_texture/8081_earthbump4k.jpg'),
+      lightMap: loadTexture('/earth_texture/8081_earthlights4k.jpg'),
       bumpScale: 0.04
     })
-    const earthMesh = new THREE.Mesh(geometry, material)
+    const earthMesh = new Mesh(geometry, material)
     earthGroup.add(earthMesh)
 
-    const lightsMat = new THREE.MeshBasicMaterial({
-      lightMap: loader.load('/earth_texture/8081_earthlights4k.jpg'),
-      blending: THREE.AdditiveBlending
+    const lightsMat = new MeshBasicMaterial({
+      lightMap: loadTexture('/earth_texture/8081_earthlights4k.jpg'),
+      blending: AdditiveBlending
     })
-    const lightsMesh = new THREE.Mesh(geometry, lightsMat)
+    const lightsMesh = new Mesh(geometry, lightsMat)
     // earthGroup.add(lightsMesh)
 
-    const cloudsMat = new THREE.MeshStandardMaterial({
-      map: loader.load('/earth_texture/earthcloudmap.jpg'),
+    const cloudsMat = new MeshStandardMaterial({
+      map: loadTexture('/earth_texture/earthcloudmap.jpg'),
       transparent: true,
       opacity: 0.5,
-      blending: THREE.AdditiveBlending,
-      alphaMap: loader.load('/earth_texture/earthcloudmaptrans.jpg')
+      blending: AdditiveBlending,
+      alphaMap: loadTexture('/earth_texture/earthcloudmaptrans.jpg')
     })
-    const cloudsMesh = new THREE.Mesh(geometry, cloudsMat)
+    const cloudsMesh = new Mesh(geometry, cloudsMat)
     cloudsMesh.scale.setScalar(1.003)
     earthGroup.add(cloudsMesh)
 
     const fresnelMat = getFresnelMat()
-    const glowMesh = new THREE.Mesh(geometry, fresnelMat)
+    const glowMesh = new Mesh(geometry, fresnelMat)
     glowMesh.scale.setScalar(1.01)
     earthGroup.add(glowMesh)
 
     const stars = getStarfield({ numStars: 1000 })
     scene.add(stars)
 
-    const sunLight = new THREE.DirectionalLight(0xffffff)
+    const sunLight = new DirectionalLight(0xffffff)
     sunLight.position.set(1, 0.5, 1.5)
     scene.add(sunLight)
 

--- a/lib/starfield.ts
+++ b/lib/starfield.ts
@@ -1,4 +1,7 @@
-import * as THREE from 'three'
+import { Vector3, BufferGeometry, Float32BufferAttribute, Points, PointsMaterial, TextureLoader, type Texture } from 'three'
+
+// Cache texture to avoid reloading on every call
+let starTexture: Texture | null = null
 
 export default function getStarfield({ numStars = 500 } = {}) {
   function randomSpherePoint() {
@@ -7,36 +10,32 @@ export default function getStarfield({ numStars = 500 } = {}) {
     const v = Math.random()
     const theta = 2 * Math.PI * u
     const phi = Math.acos(2 * v - 1)
-    let x = radius * Math.sin(phi) * Math.cos(theta)
-    let y = radius * Math.sin(phi) * Math.sin(theta)
-    let z = radius * Math.cos(phi)
+    const x = radius * Math.sin(phi) * Math.cos(theta)
+    const y = radius * Math.sin(phi) * Math.sin(theta)
+    const z = radius * Math.cos(phi)
 
     return {
-      pos: new THREE.Vector3(x, y, z),
+      pos: new Vector3(x, y, z),
       hue: 0.6,
       minDist: radius
     }
   }
-  const verts = []
-  const colors = []
-  const positions = []
-  let col
+  const verts: number[] = []
   for (let i = 0; i < numStars; i += 1) {
-    let p = randomSpherePoint()
-    const { pos, hue } = p
-    positions.push(p)
-    col = new THREE.Color().setHSL(hue, 0.2, Math.random())
+    const p = randomSpherePoint()
+    const { pos } = p
     verts.push(pos.x, pos.y, pos.z)
-    colors.push(col.r, col.g, col.b)
   }
-  const geo = new THREE.BufferGeometry()
-  geo.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3))
-  geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3))
-  const mat = new THREE.PointsMaterial({
+  const geo = new BufferGeometry()
+  geo.setAttribute('position', new Float32BufferAttribute(verts, 3))
+  // Cache texture on first call, reuse thereafter
+  if (!starTexture) {
+    starTexture = new TextureLoader().load('/earth_texture/circle.png')
+  }
+  const mat = new PointsMaterial({
     size: 0.5,
-    vertexColors: false,
-    map: new THREE.TextureLoader().load('/earth_texture/circle.png')
+    map: starTexture
   })
-  const points = new THREE.Points(geo, mat)
+  const points = new Points(geo, mat)
   return points
 }

--- a/lib/starfield.ts
+++ b/lib/starfield.ts
@@ -1,4 +1,12 @@
-import { Vector3, BufferGeometry, Float32BufferAttribute, Points, PointsMaterial, TextureLoader, type Texture } from 'three'
+import {
+  Vector3,
+  BufferGeometry,
+  Float32BufferAttribute,
+  Points,
+  PointsMaterial,
+  TextureLoader,
+  type Texture
+} from 'three'
 
 // Cache texture to avoid reloading on every call
 let starTexture: Texture | null = null
@@ -20,11 +28,14 @@ export default function getStarfield({ numStars = 500 } = {}) {
       minDist: radius
     }
   }
-  const verts: number[] = []
+  const verts = new Float32Array(numStars * 3)
   for (let i = 0; i < numStars; i += 1) {
     const p = randomSpherePoint()
     const { pos } = p
-    verts.push(pos.x, pos.y, pos.z)
+    const i3 = i * 3
+    verts[i3] = pos.x
+    verts[i3 + 1] = pos.y
+    verts[i3 + 2] = pos.z
   }
   const geo = new BufferGeometry()
   geo.setAttribute('position', new Float32BufferAttribute(verts, 3))

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,11 @@
 module.exports = {
   output: 'standalone',
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [640, 750, 828, 1080, 1200]
+  },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production'
+  }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,9 @@ module.exports = {
     deviceSizes: [640, 750, 828, 1080, 1200]
   },
   compiler: {
-    removeConsole: process.env.NODE_ENV === 'production'
+    removeConsole:
+      process.env.NODE_ENV === 'production'
+        ? { exclude: ['error', 'warn'] }
+        : false
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ export default function Website({ Component, pageProps, router }: AppProps) {
   return (
     <Chakra cookies={pageProps.cookies}>
       <Fonts />
-      <Layout router={router}>
+      <Layout router={router} baseUrl={pageProps.baseUrl}>
         <AnimatePresence
           mode="wait"
           initial={true}


### PR DESCRIPTION
## Summary
- Dynamic base URL detection for OG/Twitter meta tags — supports `dangdd.tech`, `dangdd.dev`, and `ddangw.me` automatically without hardcoding
- Switch to named Three.js imports for better tree-shaking; add module-level texture caching to avoid re-fetching 4K textures on component remounts
- Add AVIF/WebP image optimization, custom device sizes, strip console logs in production, and remove dead commented nav links

## Test plan
- [x] Verify OG meta tags reflect the correct domain on each of the 3 domains
- [x] Confirm Earth globe loads correctly with texture caching
- [x] Check no ESLint warnings in build output
- [x] Confirm nav renders correctly without Works/Articles links

🤖 Generated with [Claude Code](https://claude.com/claude-code)